### PR TITLE
Clarify binary file path label

### DIFF
--- a/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/configuration/SettingsConfigurable.kt
@@ -52,7 +52,7 @@ class SettingsConfigurable(
   override fun createPanel(): DialogPanel {
     return panel {
       group("Tinymist") {
-        buttonsGroup("Binary filepath") {
+        buttonsGroup("Binary file path") {
           row {
             automaticRadioButton = radioButton(
               "Use automatically downloaded binary (${VersionRequirement.version.toPathString()})",


### PR DESCRIPTION
## Summary
- Adjust settings label to "Binary file path" for clarity
