### PR TITLE
Add structure view for Typst documents

### DIFF
--- a/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureParser.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureParser.kt
@@ -1,0 +1,48 @@
+package com.github.garetht.typstsupport.structureview
+
+import com.intellij.psi.PsiFile
+
+data class HeadingNode(
+    val level: Int,
+    val text: String,
+    val offset: Int,
+    val children: MutableList<HeadingNode> = mutableListOf()
+)
+
+internal object TypstStructureParser {
+    fun parse(file: PsiFile): List<HeadingNode> {
+        val text = file.text
+        val headings = mutableListOf<Triple<Int, String, Int>>() // level, title, offset
+
+        val eqRegex = Regex("""(?m)^(\=+)\s+(.*)$""")
+        for (match in eqRegex.findAll(text)) {
+            val level = match.groupValues[1].length
+            val title = match.groupValues[2].trim()
+            headings += Triple(level, title, match.range.first)
+        }
+
+        val macroRegex = Regex("""(?m)^#heading(?:\(([^)]*)\))?\[(.*?)]""")
+        for (match in macroRegex.findAll(text)) {
+            val options = match.groupValues[1]
+            val title = match.groupValues[2].trim()
+            val levelMatch = Regex("""level\s*:\s*(\d+)""").find(options)
+            val level = levelMatch?.groupValues?.get(1)?.toInt() ?: 1
+            headings += Triple(level, title, match.range.first)
+        }
+
+        headings.sortBy { it.third }
+
+        val root = HeadingNode(0, "", 0)
+        val stack = mutableListOf(root)
+        for ((level, title, offset) in headings) {
+            while (stack.last().level >= level) {
+                stack.removeAt(stack.size - 1)
+            }
+            val node = HeadingNode(level, title, offset)
+            stack.last().children += node
+            stack += node
+        }
+        return root.children
+    }
+}
+

--- a/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewElement.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewElement.kt
@@ -1,0 +1,40 @@
+package com.github.garetht.typstsupport.structureview
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.util.treeView.smartTree.SortableTreeElement
+import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.psi.PsiFile
+
+class TypstStructureViewElement(
+    private val file: PsiFile,
+    private val node: HeadingNode? = null
+) : StructureViewTreeElement, SortableTreeElement {
+
+    private val myChildren: Array<StructureViewTreeElement> = if (node == null) {
+        TypstStructureParser.parse(file).map { TypstStructureViewElement(file, it) }.toTypedArray()
+    } else {
+        node.children.map { TypstStructureViewElement(file, it) }.toTypedArray()
+    }
+
+    override fun getValue(): Any = node ?: file
+
+    override fun navigate(requestFocus: Boolean) {
+        node?.let { OpenFileDescriptor(file.project, file.virtualFile, it.offset).navigate(requestFocus) }
+    }
+
+    override fun canNavigate(): Boolean = node != null
+
+    override fun canNavigateToSource(): Boolean = canNavigate()
+
+    override fun getChildren(): Array<StructureViewTreeElement> = myChildren
+
+    override fun getPresentation(): ItemPresentation = object : ItemPresentation {
+        override fun getPresentableText(): String? = node?.text ?: file.name
+        override fun getLocationString(): String? = null
+        override fun getIcon(unused: Boolean) = if (node == null) file.getIcon(0) else null
+    }
+
+    override fun getAlphaSortKey(): String = node?.text ?: file.name
+}
+

--- a/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewFactory.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewFactory.kt
@@ -1,0 +1,19 @@
+package com.github.garetht.typstsupport.structureview
+
+import com.intellij.ide.structureView.StructureViewBuilder
+import com.intellij.ide.structureView.StructureViewModel
+import com.intellij.ide.structureView.TreeBasedStructureViewBuilder
+import com.intellij.lang.PsiStructureViewFactory
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+
+class TypstStructureViewFactory : PsiStructureViewFactory {
+    override fun getStructureViewBuilder(psiFile: PsiFile): StructureViewBuilder {
+        return object : TreeBasedStructureViewBuilder() {
+            override fun createStructureViewModel(editor: Editor?): StructureViewModel {
+                return TypstStructureViewModel(psiFile)
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewModel.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewModel.kt
@@ -7,8 +7,6 @@ import com.intellij.psi.PsiFile
 class TypstStructureViewModel(psiFile: PsiFile) :
     StructureViewModelBase(psiFile, TypstStructureViewElement(psiFile)) {
 
-    override fun isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = false
-
     override fun isAlwaysLeaf(element: StructureViewTreeElement): Boolean =
         element is TypstStructureViewElement && element.children.isEmpty()
 }

--- a/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewModel.kt
+++ b/src/main/kotlin/com/github/garetht/typstsupport/structureview/TypstStructureViewModel.kt
@@ -1,0 +1,15 @@
+package com.github.garetht.typstsupport.structureview
+
+import com.intellij.ide.structureView.StructureViewModelBase
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.psi.PsiFile
+
+class TypstStructureViewModel(psiFile: PsiFile) :
+    StructureViewModelBase(psiFile, TypstStructureViewElement(psiFile)) {
+
+    override fun isAlwaysShowsPlus(element: StructureViewTreeElement): Boolean = false
+
+    override fun isAlwaysLeaf(element: StructureViewTreeElement): Boolean =
+        element is TypstStructureViewElement && element.children.isEmpty()
+}
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
                 fieldName="INSTANCE"
                 language="Typst"
                 extensions="typ"/>
+        <psiStructureViewFactory language="Typst" implementation="com.github.garetht.typstsupport.structureview.TypstStructureViewFactory"/>
         <applicationConfigurable instance="com.github.garetht.typstsupport.configuration.SettingsConfigurable"
                                  displayName="Typst Support Settings"/>
 


### PR DESCRIPTION
## Summary
- implement structure view factory and model for Typst files
- parse `=` headings and `#heading` macros to build hierarchical structure
- register structure view factory in plugin.xml
- make `HeadingNode` public so structure view element exposes only public types

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6899bc1aa1a083289ff7815efc488169